### PR TITLE
add skaffold

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,5 +30,6 @@
 **/values.dev.yaml
 **/build
 **/dist
+.nx/
 LICENSE
 README.md

--- a/.gitignore
+++ b/.gitignore
@@ -189,7 +189,7 @@ Session.vim
 ### windows
 Desktop.ini
 $RECYCLE.BIN/
-Thumbs.db 
+Thumbs.db
 
 ## commonly used temp files and directories
 *.log
@@ -214,3 +214,5 @@ TAGS
 
 # nx
 .nx
+
+infrastructure/kustomize/postgres/base/charts

--- a/apps/api/Dockerfile.dev
+++ b/apps/api/Dockerfile.dev
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1
+
+ARG NODE_VERSION=18.17.0
+ARG PNPM_VERSION=8.9.2
+
+################################################################################
+# Use node image for base image for all stages.
+FROM node:${NODE_VERSION}-alpine as base
+
+# Set working directory for all build stages.
+WORKDIR /usr/src/app
+
+# Install pnpm.
+RUN --mount=type=cache,target=/root/.npm \
+  npm install -g pnpm@${PNPM_VERSION}
+
+RUN --mount=type=bind,source=package.json,target=package.json \
+  --mount=type=bind,source=pnpm-lock.yaml,target=pnpm-lock.yaml \
+  --mount=type=cache,target=/root/.local/share/pnpm/store \
+  pnpm install --frozen-lockfile
+
+COPY . .
+
+# Generate the Prisma bindings.
+RUN pnpm prisma:generate
+
+FROM base as final
+
+# Expose the ports that the application listens on.
+EXPOSE 3100 9100
+
+# Run the application.
+CMD ["pnpm", "dev:api"]

--- a/apps/www/Dockerfile.dev
+++ b/apps/www/Dockerfile.dev
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1
+
+ARG NODE_VERSION=18.17.0
+ARG PNPM_VERSION=8.9.2
+
+################################################################################
+# Use node image for base image for all stages.
+FROM node:${NODE_VERSION}-alpine as base
+
+# Set working directory for all build stages.
+WORKDIR /usr/src/app
+
+# Install pnpm.
+RUN --mount=type=cache,target=/root/.npm \
+  npm install -g pnpm@${PNPM_VERSION}
+
+RUN --mount=type=bind,source=package.json,target=package.json \
+  --mount=type=bind,source=pnpm-lock.yaml,target=pnpm-lock.yaml \
+  --mount=type=cache,target=/root/.local/share/pnpm/store \
+  pnpm install --frozen-lockfile
+
+COPY . .
+
+# Generate the Prisma bindings.
+RUN pnpm prisma:generate
+
+FROM base as final
+
+# Expose the ports that the application listens on.
+EXPOSE 4200
+
+# Run the application.
+CMD ["pnpm", "dev:www", "--", "--hostname=0.0.0.0"]

--- a/infrastructure/kustomize/api/base/deployment.yaml
+++ b/infrastructure/kustomize/api/base/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  selector:
+    matchLabels:
+      run: api
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: api
+    spec:
+      containers:
+        - name: api
+          image: api
+          ports:
+          - containerPort: 3100
+

--- a/infrastructure/kustomize/api/base/kustomization.yaml
+++ b/infrastructure/kustomize/api/base/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- deployment.yaml
+- service.yaml

--- a/infrastructure/kustomize/api/base/service.yaml
+++ b/infrastructure/kustomize/api/base/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  labels:
+    run: api
+spec:
+  ports:
+  - port: 3100
+    protocol: TCP
+    targetPort: 3100
+  selector:
+    run: api

--- a/infrastructure/kustomize/api/local/ingress.yaml
+++ b/infrastructure/kustomize/api/local/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: api
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+    # Replace with your domain
+    # You can use sslip.io for testing
+    - host: api.k8s.orb.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: api
+                port:
+                  number: 3100

--- a/infrastructure/kustomize/api/local/kustomization.yaml
+++ b/infrastructure/kustomize/api/local/kustomization.yaml
@@ -1,0 +1,21 @@
+resources:
+- ../../postgres/base
+- ../base
+- ingress.yaml
+namePrefix: local-
+
+configMapGenerator:
+- name: api-configmap
+  literals:
+  - DATABASE_URL=postgresql://postgres:postgres@local-postgresql:5432/postgres
+
+patches:
+- patch: |-
+    - op: add
+      path: "/spec/template/spec/containers/0/envFrom"
+      value:
+      - configMapRef:
+          name: local-api-configmap
+  target:
+    kind: Deployment
+    name: api

--- a/infrastructure/kustomize/postgres/base/kustomization.yaml
+++ b/infrastructure/kustomize/postgres/base/kustomization.yaml
@@ -1,0 +1,12 @@
+helmCharts:
+- name: postgresql
+  valuesInline:
+    global:
+      postgresql:
+        auth:
+          postgresPassword: postgres
+          username: postgres
+          password: postgres
+          database: postgres
+  releaseName: postgresql
+  repo: https://charts.bitnami.com/bitnami

--- a/infrastructure/kustomize/www/base/deployment.yaml
+++ b/infrastructure/kustomize/www/base/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: www
+spec:
+  selector:
+    matchLabels:
+      run: www
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: www
+    spec:
+      containers:
+      - name: www
+        image: www
+        ports:
+        - containerPort: 3000

--- a/infrastructure/kustomize/www/base/kustomization.yaml
+++ b/infrastructure/kustomize/www/base/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- deployment.yaml
+- service.yaml

--- a/infrastructure/kustomize/www/base/service.yaml
+++ b/infrastructure/kustomize/www/base/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: www
+  labels:
+    run: www
+spec:
+  ports:
+  - port: 3000
+    protocol: TCP
+    targetPort: 3000
+  selector:
+    run: www

--- a/infrastructure/kustomize/www/local/ingress.yaml
+++ b/infrastructure/kustomize/www/local/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: www
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+    # Replace with your domain
+    # You can use sslip.io for testing
+    - host: www.k8s.orb.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: www
+                port:
+                  number: 3000

--- a/infrastructure/kustomize/www/local/kustomization.yaml
+++ b/infrastructure/kustomize/www/local/kustomization.yaml
@@ -1,0 +1,21 @@
+resources:
+- ../base
+- ingress.yaml
+namePrefix: local-
+
+patches:
+- patch: |-
+    - op: replace
+      path: "/spec/ports/0/targetPort"
+      value: 4200
+  target:
+    kind: Service
+    name: www
+
+- patch: |-
+    - op: replace
+      path: "/spec/template/spec/containers/0/ports/0/containerPort"
+      value: 4200
+  target:
+    kind: Deployment
+    name: www

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build:www": "nx run www:build",
     "build:docker:api": "docker build -f apps/api/Dockerfile .",
     "build:docker:www": "docker build -f apps/www/Dockerfile .",
+    "dev": "skaffold dev --port-forward",
     "dev:api": "nx run api:serve:development --watch=true",
     "dev:www": "nx run www:serve:development --watch=true",
     "docker:dev": "docker compose -f docker-compose.base.yaml -f docker-compose.dev.yaml",

--- a/packages/database/src/lib/prisma.service.ts
+++ b/packages/database/src/lib/prisma.service.ts
@@ -1,9 +1,20 @@
-import { Injectable, OnModuleInit } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
 
 @Injectable()
 export class PrismaService extends PrismaClient implements OnModuleInit {
+  private readonly logger = new Logger(PrismaService.name);
+
   async onModuleInit() {
-    await this.$connect();
+    for (let i = 0; i < 10; i++) {
+      try {
+        await this.$connect();
+        return;
+      } catch (e) {
+        this.logger.error(`Failed to connect to database (${i})`);
+        this.logger.error(e);
+        await new Promise((r) => setTimeout(r, 1000));
+      }
+    }
   }
 }

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,44 @@
+apiVersion: skaffold/v4beta9
+kind: Config
+metadata:
+  name: nx-next-nest-prisma-ory-template
+build:
+  artifacts:
+    - image: api
+      context: .
+      docker:
+        dockerfile: apps/api/Dockerfile.dev
+      sync:
+        manual:
+          # sync src files since we are running a dev server
+          - src: 'apps/api/*'
+            dest: /usr/src/app
+          - src: 'packages/**/*'
+            dest: /usr/src/app
+
+    - image: www
+      context: .
+      docker:
+        dockerfile: apps/www/Dockerfile.dev
+      sync:
+        manual:
+          # sync src files since we are running a dev server
+          - src: 'apps/www/*'
+            dest: /usr/src/app
+          - src: 'packages/**/*'
+            dest: /usr/src/app
+  local: 
+    useBuildkit: true
+    push: false
+
+deploy:
+  statusCheckDeadlineSeconds: 30
+  tolerateFailuresUntilDeadline: true
+    
+manifests:
+  kustomize:
+    paths:
+      - infrastructure/kustomize/api/local
+      - infrastructure/kustomize/www/local
+    buildArgs:
+      - "--enable-helm"


### PR DESCRIPTION
This PR adds [Skaffold](https://skaffold.dev) as a dev solution. The main idea is to replicate a close to production environment while developing applications.

The goal was to push a developer experience that doesn't compromise ease of use like you would on a local development environment using docker compose and nodemon. When running `skaffold dev`, skaffold will build docker images, push them to the cluster in the current kubernetes context, and sync any source code modifications by copying file directly inside the container. This means that, excepts on first launch, no other docker build happens. This allows for extremely fast iterations, just like you would on a more traditional setup.

To do so, this PR brings the following changes:
- Retry DB connections, inside the database module. This is to avoid api crashes on first startup, when the database is not yet ready.
- A dev dockerfile, that launches the app in development mode, watching for source file changes.
- Kustomize templates for the api and www apps, with local overlays that takes into account specificities of a dev environment. For example, we start a postgres with the API, so that the developer doesn't have to start one when developing.
- Skaffold configuration

Any feedback is welcome